### PR TITLE
expand dashboard's background-color range

### DIFF
--- a/frontend/app/(dashboard)/layout.tsx
+++ b/frontend/app/(dashboard)/layout.tsx
@@ -36,11 +36,11 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
 	return (
 		<html lang="ja">
 			<TooltipProvider>
-				<body className={`${geistSans.variable} ${geistMono.variable} antialiased h-screen`}>
+				<body className={`${geistSans.variable} ${geistMono.variable} antialiased h-auto`}>
 					<SidebarProvider>
 						<AppSidebar />
-						<main className={`h-screen w-screen bg-gradient-to-br ${!isDarkTheme ? 'from-pink-200 to-blue-200' : 'from-gray-900 to-purple-900'}`}>
-							<div className={`h-full w-full`}>
+						<main className={`h-auto w-screen bg-gradient-to-br ${!isDarkTheme ? 'from-pink-200 to-blue-200' : 'from-gray-900 to-purple-900'}`}>
+							<div className={`h-auto w-full`}>
 								<div className={`flex justify-start`}>
 									<SidebarTrigger />
 									<div className="flex justify-between items-center mb-6">

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-backgroun transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {


### PR DESCRIPTION
メモリストの縦幅が画面以上に伸びてしまったとき、背景が途中で途切れていたので、修正しました。